### PR TITLE
Inaccurate calculate of the ping

### DIFF
--- a/commands/ping.js
+++ b/commands/ping.js
@@ -13,7 +13,7 @@ module.exports = {
     try {
 
       const start = Date.now();
-      interaction.reply("Pong!").then(msg => {
+      interaction.reply("0").then(msg => {
         const end = Date.now();
         const embed = new EmbedBuilder()
           .setColor(client.config.embedColor)


### PR DESCRIPTION
Sending a long and unnecessary data snippet like `ping` will only increase the delay. Here we need to measure the latency between Discord and the Bot, not the long message sending. **So the smaller the length of the outgoing packet, the more accurate data we get.** I have used `0` for now, but we can change it in the future.